### PR TITLE
Implement Multi-Prompting & Minor Bugfixes

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -146,6 +146,15 @@ async def query_stable_diffusion(prompt, sleep_time=90, variations=1, size="1024
         print('[E]', traceback.format_exc())
         sys.exit(1)
 
+async def format_multiprompt(prompt):
+    multiprompt = []
+    delimiter = "|"
+    raw_multiprompt = prompt.split(delimiter)
+    for subprompt in raw_multiprompt:
+        # TODO: implement weighting, update generation.Prompt args with weighting.
+        multiprompt.append(generation.Prompt(text=subprompt)) # weight is defaulting to 1
+    return multiprompt
+
 async def query_dalle(prompt, message_ctx=None, sleep_time=90, variations=1, size="1024x1024"):
     try:
         async with aiohttp.ClientSession() as session:
@@ -295,6 +304,7 @@ async def generate_response(prompt, messages, message_ctx):
             return dfo_list
         elif prompt.startswith("!sdimagetest"):
             prompt = prompt[12:].lstrip()
+            prompt = format_multiprompt(prompt)
             await send_channel_msg(message_ctx, "Received Advanced SDImage command, generating stable-diffusion images for prompt.")
             answer = await query_stable_diffusion(prompt)
             dfo_list = await sd_file_from_answers(answer, message_ctx)  

--- a/src/bot.py
+++ b/src/bot.py
@@ -289,7 +289,7 @@ async def generate_response(prompt, messages, message_ctx):
             return dfo_list
         elif prompt.startswith("!sdimage"):
             prompt = prompt[8:].lstrip()
-            await send_channel_msg(message_ctx, "Received Image command, generating stable-diffusion images for prompt.")
+            await send_channel_msg(message_ctx, "Received SDImage command, generating stable-diffusion images for prompt.")
             answer = await query_stable_diffusion(prompt)
             dfo_list = await sd_file_from_answers(answer, message_ctx)  
             return dfo_list

--- a/src/bot.py
+++ b/src/bot.py
@@ -293,6 +293,12 @@ async def generate_response(prompt, messages, message_ctx):
             answer = await query_stable_diffusion(prompt)
             dfo_list = await sd_file_from_answers(answer, message_ctx)  
             return dfo_list
+        elif prompt.startswith("!sdimagetest"):
+            prompt = prompt[12:].lstrip()
+            await send_channel_msg(message_ctx, "Received Advanced SDImage command, generating stable-diffusion images for prompt.")
+            answer = await query_stable_diffusion(prompt)
+            dfo_list = await sd_file_from_answers(answer, message_ctx)  
+            return dfo_list
         elif prompt.startswith("!code"):
             prompt = prompt[5:].lstrip()
             await send_channel_msg(message_ctx, "Received code command, sending request with prompt to disable safeguards and RFC for long messages (this command does not keep context).")

--- a/src/bot.py
+++ b/src/bot.py
@@ -150,9 +150,12 @@ async def format_multiprompt(prompt):
     multiprompt = []
     delimiter = "|"
     raw_multiprompt = prompt.split(delimiter)
-    for subprompt in raw_multiprompt:
-        # TODO: implement weighting, update generation.Prompt args with weighting.
-        multiprompt.append(generation.Prompt(text=subprompt)) # weight is defaulting to 1
+    for index, subprompt in enumerate(raw_multiprompt):
+        if index == 0:
+            weight = 1
+        else:
+            weight = -1
+        multiprompt.append(generation.Prompt(text=subprompt,parameters=generation.PromptParameters(weight=weight)))
     return multiprompt
 
 async def query_dalle(prompt, message_ctx=None, sleep_time=90, variations=1, size="1024x1024"):

--- a/src/bot.py
+++ b/src/bot.py
@@ -282,7 +282,7 @@ async def generate_response(prompt, messages, message_ctx):
             await add_context(message_ctx, {"role": "assistant", "content": prompt})
             return None
         elif prompt.startswith("!image"):
-            prompt = prompt[7:].lstrip()
+            prompt = prompt[6:].lstrip()
             await send_channel_msg(message_ctx, "Received Image command, generating images for prompt.")
             images = await query_dalle(prompt, message_ctx)
             dfo_list = await dalle_file_from_url(images)  

--- a/src/bot.py
+++ b/src/bot.py
@@ -288,7 +288,7 @@ async def generate_response(prompt, messages, message_ctx):
             dfo_list = await dalle_file_from_url(images)  
             return dfo_list
         elif prompt.startswith("!sdimage"):
-            prompt = prompt[9:].lstrip()
+            prompt = prompt[8:].lstrip()
             await send_channel_msg(message_ctx, "Received Image command, generating stable-diffusion images for prompt.")
             answer = await query_stable_diffusion(prompt)
             dfo_list = await sd_file_from_answers(answer, message_ctx)  

--- a/src/bot.py
+++ b/src/bot.py
@@ -288,7 +288,7 @@ async def generate_response(prompt, messages, message_ctx):
             dfo_list = await dalle_file_from_url(images)  
             return dfo_list
         elif prompt.startswith("!sdimage"):
-            prompt = prompt[7:].lstrip()
+            prompt = prompt[9:].lstrip()
             await send_channel_msg(message_ctx, "Received Image command, generating stable-diffusion images for prompt.")
             answer = await query_stable_diffusion(prompt)
             dfo_list = await sd_file_from_answers(answer, message_ctx)  


### PR DESCRIPTION
Primary addition is an additional discord command `!sdimagetest` to avoid breaking the normal `sdimage` command, and a new function that will split the incoming prompt based on a (currently hardcoded as a pipe `|`) and format it into a list for StabilityAI's multi-prompting workflow. The prompt before the pipe has a weight of 1, while the prompt after has a weight of -1, allowing for negative prompts. This is useful for steering the image generation away from things that you want the model to avoid. 

There's a few pitfalls to work out - someone could submit multiple prompts, but every prompt after the first will be treated as negative - but this should help refine the overall output. I'll keep tweaking the function, 'cause I am certain there's a way to get custom weights, but I want to avoid having to add regex to the script for now.

Also tweaked some of the string slices as the `!sdimage` slice was leaving the 'e' at the end, and while fixing that i tried to align the others to end right after the final character of the command so the lstrip call would trim the same whitespace amount each time.